### PR TITLE
explicit python2 and system-site-package for _venv

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,7 +11,7 @@ VENV="_venv"
 if [ -d "$VENV" ]; then
     . "$VENV"/bin/activate
 else
-    virtualenv _venv
+    virtualenv --system-site-packages -p python2 _venv
     . "$VENV"/bin/activate
     pip install git+https://github.com/lazka/pgi.git
     pip install sphinx


### PR DESCRIPTION
The explicit use of python2 is usefull on distributions where python3 is the
default python.

The use of system-site-packages was nessesary on my installation. Without
pgi-docgen was unable to import `gi.repository`.
