### PR TITLE
Fix shebangs to use correct python interpreter

### DIFF
--- a/misc/verify-debug.py
+++ b/misc/verify-debug.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2016 Christoph Reiter
 #
 # This library is free software; you can redistribute it and/or

--- a/pgi-docgen
+++ b/pgi-docgen
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2013, 2014 Christoph Reiter
 #
 # This library is free software; you can redistribute it and/or

--- a/pgidocgen/create_debian.py
+++ b/pgidocgen/create_debian.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2015 Christoph Reiter
 #
 # This library is free software; you can redistribute it and/or

--- a/pgidocgen/debian.py
+++ b/pgidocgen/debian.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Christoph Reiter
 #
 # This library is free software; you can redistribute it and/or

--- a/pgidocgen/mergeindex.py
+++ b/pgidocgen/mergeindex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2014,2016 Christoph Reiter
 #
 # This library is free software; you can redistribute it and/or

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2015 Christoph Reiter
 #
 # This library is free software; you can redistribute it and/or


### PR DESCRIPTION
For example, when `./tools/build.sh` is executed under env created by `./tools/bootstrap.sh` this will select python executable from env instead of the system one.