### PR TITLE
Handle percent-escaped hash in target URL fragment

### DIFF
--- a/pgidocgen/gen/data/index/index.html
+++ b/pgidocgen/gen/data/index/index.html
@@ -12,26 +12,29 @@ var main_page = "main.html";
 function applyHash() {
     // takes the current hash loads the path into the content frame
 
-    var hash = window.location.hash;
-    var elm = document.getElementById('Content');
-    var new_src;
+    var hash = window.location.hash.substring(1);
+    var contentFrame = document.getElementById("Content");
+    var newSrc = main_page;
 
-    if(hash) {
-        // needed for webkit
-        if(!endsWith(hash, ".html") && !endsWith(hash, "/") && hash.indexOf("#", 1) < 0)
-            hash += "/";
-
-        new_src = hash.substring(1);
-    } else {
-        new_src= main_page;
+    if (hash) {
+        if (hash.indexOf("#") < 0) {
+            if (hash.indexOf("%23") > 0) {
+                // unescape first percent-escaped hash
+                hash = hash.replace("%23", "#");
+            } else if (!endsWith(hash, ".html") && !endsWith(hash, "/")) {
+                hash += "/"; // needed for webkit
+            }
+        }
+        newSrc = hash;
     }
 
     // create a dummy element so we can compare the URLs; prevents
     // flashing on chrome when the same url is set twice on start
     var dummy = document.createElement("a");
-    dummy.href = new_src;
-    if(dummy.href != elm.src)
-        elm.src = new_src;
+    dummy.href = newSrc;
+    if(dummy.href != contentFrame.src) {
+        contentFrame.src = newSrc;
+    }
 }
 
 


### PR DESCRIPTION
Proposed workaround for #198.